### PR TITLE
Format Option 2 in README.md as code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ At this point, you might need to restart Linkinus to see the new changes.
 
 ### Option 2 - Git
 
-1. cd `~/Library/Containers/com.codeux.irc.textual/Data/Library/Application Support/Textual IRC/Styles`
-2. git clone git://github.com/rtgibbons/textual-simplified-solarized-dark.git`
+    cd ~/Library/Containers/com.codeux.irc.textual/Data/Library/Application Support/Textual IRC/Styles
+    git clone git://github.com/rtgibbons/textual-simplified-solarized-dark.git
 
 
 [textual]: http://www.codeux.com/textual/


### PR DESCRIPTION
The previous formatting mixed code not formatted as code, code formatted as code, and code that was nearly formatted as code in an ordered list. This unnecessarily complicated things and made it more difficult to simply copy and paste the commands.

This commit re-formats the "Option 2" section of the README to make it easier to read and easier to use.
